### PR TITLE
Rename revocation to status list

### DIFF
--- a/lib/src/main/java/com/hedera/hashgraph/identity/hfs/vc/sl/sdk/HfsVcSl.java
+++ b/lib/src/main/java/com/hedera/hashgraph/identity/hfs/vc/sl/sdk/HfsVcSl.java
@@ -18,8 +18,8 @@ public class HfsVcSl {
         this.vcStatusListOwnerPrivateKey = vcStatusListOwnerPrivateKey;
     }
 
-    public FileId createRevocationListFile() throws PrecheckStatusException, TimeoutException, ReceiptStatusException, IOException {
-        RevocationList vcStatusList = new RevocationList();
+    public FileId createStatusListFile() throws PrecheckStatusException, TimeoutException, ReceiptStatusException, IOException {
+        StatusList vcStatusList = new StatusList();
         String encodedVcStatusList = vcStatusList.encode();
 
         FileCreateTransaction transaction = new FileCreateTransaction()
@@ -35,11 +35,11 @@ public class HfsVcSl {
         return txReceipt.fileId;
     }
 
-    public RevocationList loadRevocationList(FileId vcStatusFileId) throws PrecheckStatusException, TimeoutException, IOException {
+    public StatusList loadStatusList(FileId vcStatusFileId) throws PrecheckStatusException, TimeoutException, IOException {
         FileContentsQuery query = new FileContentsQuery().setFileId(vcStatusFileId);
         ByteString encodedStatusList = query.execute(this.client);
 
-        return RevocationList.decodeList(encodedStatusList.toStringUtf8());
+        return StatusList.decodeList(encodedStatusList.toStringUtf8());
     }
 
     public void revokeByIndex(FileId vcStatusListFileId, int vcStatusListIndex) throws Exception {
@@ -59,7 +59,7 @@ public class HfsVcSl {
     }
 
     public VcSlStatus resolveStatusByIndex(FileId vcStatusListFileId, int vcStatusListIndex) throws Exception {
-        RevocationList list = this.loadRevocationList(vcStatusListFileId);
+        StatusList list = this.loadStatusList(vcStatusListFileId);
 
         if (!list.isRevoked(vcStatusListIndex) && !list.isRevoked(vcStatusListIndex + 1)) {
             return VcSlStatus.ACTIVE;
@@ -78,12 +78,12 @@ public class HfsVcSl {
      * Private functions
      */
 
-    private RevocationList updateStatus(FileId vcStatusListFileId, int vcStatusListIndex, VcSlStatus status) throws Exception {
+    private StatusList updateStatus(FileId vcStatusListFileId, int vcStatusListIndex, VcSlStatus status) throws Exception {
         if (vcStatusListIndex % 2 != 0) {
             throw new Error("vcStatusListIndex must be Multiples of 2 OR 0. e.g. 0, 2, 4, 6, 8, 10, 12, 14");
         }
 
-        RevocationList list = this.loadRevocationList(vcStatusListFileId);
+        StatusList list = this.loadStatusList(vcStatusListFileId);
 
         switch (status) {
             case ACTIVE:

--- a/lib/src/main/java/com/hedera/hashgraph/identity/hfs/vc/sl/sdk/StatusList.java
+++ b/lib/src/main/java/com/hedera/hashgraph/identity/hfs/vc/sl/sdk/StatusList.java
@@ -8,7 +8,7 @@ import java.util.BitSet;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
-public class RevocationList {
+public class StatusList {
     public final static int DEFAULT_LIST_BIT_SIZE = 100_032;
 
     private final BitSet bitset;
@@ -17,17 +17,17 @@ public class RevocationList {
      */
     private final int size;
 
-    public RevocationList() {
-        this.bitset = new BitSet(RevocationList.DEFAULT_LIST_BIT_SIZE);
+    public StatusList() {
+        this.bitset = new BitSet(StatusList.DEFAULT_LIST_BIT_SIZE);
         this.size = this.bitset.size();
     }
 
-    public RevocationList(int number) {
+    public StatusList(int number) {
         this.bitset = new BitSet(number);
         this.size = this.bitset.size();
     }
 
-    public RevocationList(BitSet bitset) {
+    public StatusList(BitSet bitset) {
         this.bitset = bitset;
         this.size = this.bitset.size();
     }
@@ -61,7 +61,7 @@ public class RevocationList {
         return Base64.getUrlEncoder().encodeToString(bos.toByteArray());
     }
 
-    public static RevocationList decodeList(String encodedList) throws IOException {
+    public static StatusList decodeList(String encodedList) throws IOException {
         byte[] compressedBitset = Base64.getUrlDecoder().decode(encodedList);
 
         ByteArrayInputStream bos = new ByteArrayInputStream(compressedBitset);
@@ -75,7 +75,7 @@ public class RevocationList {
 
         resultBitset.or(optimizedBitset);
 
-        return new RevocationList(resultBitset);
+        return new StatusList(resultBitset);
     }
 
 }

--- a/lib/src/test/java/com/hedera/hashgraph/identity/hfs/vc/sl/sdk/HfsVcSlIntegrationTest.java
+++ b/lib/src/test/java/com/hedera/hashgraph/identity/hfs/vc/sl/sdk/HfsVcSlIntegrationTest.java
@@ -40,20 +40,20 @@ class HfsVcSlIntegrationTest {
             PrivateKey operatorKey = PrivateKey.fromString(prop.getProperty("OPERATOR_KEY"));
             client.setOperator(operatorId, operatorKey);
 
-            HfsVcSlIntegrationTest.fileId = new HfsVcSl(HfsVcSlIntegrationTest.client, HfsVcSlIntegrationTest.fileKey).createRevocationListFile();
+            HfsVcSlIntegrationTest.fileId = new HfsVcSl(HfsVcSlIntegrationTest.client, HfsVcSlIntegrationTest.fileKey).createStatusListFile();
         } catch (Exception ex) {
             ex.printStackTrace();
         }
     }
 
     /**
-     * #createRevocationListFile
+     * #createStatusListFile
      */
 
     @Test
     @Order(111)
-    @DisplayName("creates a revocation list on HFS")
-    void itCreatesRevocationList() throws PrecheckStatusException, TimeoutException {
+    @DisplayName("creates a status list on HFS")
+    void itCreatesStatusList() throws PrecheckStatusException, TimeoutException {
         FileContentsQuery query = new FileContentsQuery().setFileId(HfsVcSlIntegrationTest.fileId);
         ByteString encodedStatusList = query.execute(HfsVcSlIntegrationTest.client);
         assertTrue(encodedStatusList.toStringUtf8().startsWith("H4sIAAAAAA"));
@@ -61,7 +61,7 @@ class HfsVcSlIntegrationTest {
     }
 
     /**
-     * #loadRevocationList
+     * #loadStatusList
      */
 
     @Test
@@ -69,7 +69,7 @@ class HfsVcSlIntegrationTest {
     @DisplayName("loads file and returns a status list")
     void itLoadsStatusListFileContent() throws PrecheckStatusException, TimeoutException, IOException {
         HfsVcSl hfsVcSl = new HfsVcSl(HfsVcSlIntegrationTest.client, HfsVcSlIntegrationTest.fileKey);
-        RevocationList list = hfsVcSl.loadRevocationList(HfsVcSlIntegrationTest.fileId);
+        StatusList list = hfsVcSl.loadStatusList(HfsVcSlIntegrationTest.fileId);
 
         assertEquals(100032, list.getSize());
 
@@ -84,7 +84,7 @@ class HfsVcSlIntegrationTest {
 
     @Test
     @Order(311)
-    @DisplayName("should apply revoked status to revocation list index 0")
+    @DisplayName("should apply revoked status to status list index 0")
     void itSetsCredentialStatusToRevoked() throws Exception {
         HfsVcSl hfsVcSl = new HfsVcSl(HfsVcSlIntegrationTest.client, HfsVcSlIntegrationTest.fileKey);
         hfsVcSl.revokeByIndex(HfsVcSlIntegrationTest.fileId, 0);
@@ -94,7 +94,7 @@ class HfsVcSlIntegrationTest {
 
     @Test
     @Order(312)
-    @DisplayName("should apply suspended status to revocation list index 0")
+    @DisplayName("should apply suspended status to status list index 0")
     void itSetsCredentialStatusToSuspended() throws Exception {
         HfsVcSl hfsVcSl = new HfsVcSl(HfsVcSlIntegrationTest.client, HfsVcSlIntegrationTest.fileKey);
         hfsVcSl.suspendByIndex(HfsVcSlIntegrationTest.fileId, 0);
@@ -104,7 +104,7 @@ class HfsVcSlIntegrationTest {
 
     @Test
     @Order(313)
-    @DisplayName("should apply resumed status to revocation list index 0")
+    @DisplayName("should apply resumed status to status list index 0")
     void itSetsCredentialStatusToResumed() throws Exception {
         HfsVcSl hfsVcSl = new HfsVcSl(HfsVcSlIntegrationTest.client, HfsVcSlIntegrationTest.fileKey);
         hfsVcSl.resumeByIndex(HfsVcSlIntegrationTest.fileId, 0);
@@ -114,7 +114,7 @@ class HfsVcSlIntegrationTest {
 
     @Test
     @Order(314)
-    @DisplayName("should apply active status to revocation list index 0")
+    @DisplayName("should apply active status to status list index 0")
     void itSetsCredentialStatusToActive() throws Exception {
         HfsVcSl hfsVcSl = new HfsVcSl(HfsVcSlIntegrationTest.client, HfsVcSlIntegrationTest.fileKey);
         hfsVcSl.issueByIndex(HfsVcSlIntegrationTest.fileId, 0);

--- a/lib/src/test/java/com/hedera/hashgraph/identity/hfs/vc/sl/sdk/StatusListTest.java
+++ b/lib/src/test/java/com/hedera/hashgraph/identity/hfs/vc/sl/sdk/StatusListTest.java
@@ -10,27 +10,27 @@ import java.util.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 @Tag("unit")
-public class RevocationListTest {
+public class StatusListTest {
 
     @Test
-    @DisplayName("Creates new empty revocation list")
-    void itCreatesEmptyRevocationList() {
-        RevocationList list = new RevocationList();
-        assertEquals(RevocationList.DEFAULT_LIST_BIT_SIZE, list.getSize());
+    @DisplayName("Creates new empty status list")
+    void itCreatesEmptyStatusList() {
+        StatusList list = new StatusList();
+        assertEquals(StatusList.DEFAULT_LIST_BIT_SIZE, list.getSize());
     }
 
     @Test
     @DisplayName("Creates empty list of set size")
-    void itCreatesEmptyRevocationListOfProvidedSize() {
-        RevocationList list = new RevocationList(128);
+    void itCreatesEmptyStatusListOfProvidedSize() {
+        StatusList list = new StatusList(128);
         assertEquals(128, list.getSize());
     }
 
     @Test
     @DisplayName("Creates list from bitset instance")
-    void itCreatesRevocationListFromProvidedBitSetInstance() {
+    void itCreatesStatusListFromProvidedBitSetInstance() {
         BitSet bitset = new BitSet(1024);
-        RevocationList list = new RevocationList(bitset);
+        StatusList list = new StatusList(bitset);
         assertEquals(1024, list.getSize());
         assertEquals(bitset, list.getBitset());
     }
@@ -38,7 +38,7 @@ public class RevocationListTest {
     @Test
     @DisplayName("It sets bits to revoked status and later back")
     void itSetsBitsToRevokedStatus() {
-        RevocationList list = new RevocationList();
+        StatusList list = new StatusList();
         int[] indices = new int[]{11, 12, 65432, 65433, 99999};
 
         for (int index: indices) {
@@ -57,28 +57,28 @@ public class RevocationListTest {
     @Test
     @DisplayName("It sets bits to revoked and back. Uses API function to check the status")
     void itSetsBitsToRevokedStatusAndChecksItByUsingInstanceApi() {
-        RevocationList list = new RevocationList();
+        StatusList list = new StatusList();
         int[] indices = new int[]{11, 12, 65432, 65433, 99999};
 
         for (int index: indices) {
             list.setRevoked(index, true);
         }
 
-        validateRevocationListValues(list, indices);
+        validateStatusListValues(list, indices);
 
         for (int index: indices) {
             list.setRevoked(index, false);
         }
 
-        validateRevocationListValues(list, new int[]{});
+        validateStatusListValues(list, new int[]{});
     }
 
     @Test
     @DisplayName("Encodes an empty list")
     void itEncodesAnEmptyList() throws IOException {
-        RevocationList list = new RevocationList();
+        StatusList list = new StatusList();
         String listEncoded = list.encode();
-        RevocationList decodedList = RevocationList.decodeList(listEncoded);
+        StatusList decodedList = StatusList.decodeList(listEncoded);
 
         assertEquals(decodedList.getSize(), list.getSize());
         assertEquals(decodedList.getBitset(), list.getBitset());
@@ -87,13 +87,13 @@ public class RevocationListTest {
     @Test
     @DisplayName("Encodes a list with some bits set to true")
     void itEncodesAListWithBitsSetToTrue() throws IOException {
-        RevocationList list = new RevocationList();
+        StatusList list = new StatusList();
         int[] indices = new int[]{11, 12, 65432, 65433, 99999};
         for (int index: indices) {
             list.setRevoked(index, true);
         }
         String listEncoded = list.encode();
-        RevocationList decodedList = RevocationList.decodeList(listEncoded);
+        StatusList decodedList = StatusList.decodeList(listEncoded);
 
         assertEquals(decodedList.getSize(), list.getSize());
         assertEquals(decodedList.getBitset(), list.getBitset());
@@ -102,17 +102,17 @@ public class RevocationListTest {
     @Test
     @DisplayName("Decodes an empty list")
     void itDecodesAnEmptyList() throws IOException {
-        RevocationList list = RevocationList.decodeList("H4sIAAAAAAAAAO3BMQEAAADCoPVPbQwfoAAAAAAAAAAAAAAAAD4GQx1mVtgwAAA=");
-        assertEquals(RevocationList.DEFAULT_LIST_BIT_SIZE, list.getSize());
-        validateRevocationListValues(list, new int[]{});
+        StatusList list = StatusList.decodeList("H4sIAAAAAAAAAO3BMQEAAADCoPVPbQwfoAAAAAAAAAAAAAAAAD4GQx1mVtgwAAA=");
+        assertEquals(StatusList.DEFAULT_LIST_BIT_SIZE, list.getSize());
+        validateStatusListValues(list, new int[]{});
     }
 
     @Test
     @DisplayName("Decodes list with some bits updated")
     void itDecodesListWithSomeBitsUpdated() throws IOException {
-        RevocationList list = RevocationList.decodeList("H4sIAAAAAAAAAO3OsQkAMAgAQcElHDejB2ewEOGu-PqjAgAAAAAAAAC4J7cHAAAAAIZe5wNOuM282DAAAA==");
-        assertEquals(RevocationList.DEFAULT_LIST_BIT_SIZE, list.getSize());
-        validateRevocationListValues(list, new int[]{11, 12, 65432, 65433, 99999});
+        StatusList list = StatusList.decodeList("H4sIAAAAAAAAAO3OsQkAMAgAQcElHDejB2ewEOGu-PqjAgAAAAAAAAC4J7cHAAAAAIZe5wNOuM282DAAAA==");
+        assertEquals(StatusList.DEFAULT_LIST_BIT_SIZE, list.getSize());
+        validateStatusListValues(list, new int[]{11, 12, 65432, 65433, 99999});
     }
 
     /**
@@ -122,15 +122,15 @@ public class RevocationListTest {
     @Test
     @DisplayName("All bits set as revoked generated by javascript version of the lib")
     void itDecodesAndFindsAllBitsRevoked() throws IOException {
-        RevocationList list = RevocationList.decodeList("H4sIAAAAAAAAA-3BMQEAAADCoP6pZwwfoAAAAAAAAAAAAAAAAD4G48MqJdgwAAA");
-        assertEquals(RevocationList.DEFAULT_LIST_BIT_SIZE, list.getSize());
+        StatusList list = StatusList.decodeList("H4sIAAAAAAAAA-3BMQEAAADCoP6pZwwfoAAAAAAAAAAAAAAAAD4G48MqJdgwAAA");
+        assertEquals(StatusList.DEFAULT_LIST_BIT_SIZE, list.getSize());
         int[] indcides = new int[100032];
 
         for (int i = 0; i < 100032; i++) {
             indcides[i] = i;
         }
 
-        validateRevocationListValues(list, indcides);
+        validateStatusListValues(list, indcides);
     }
 
     private final Map<String, int[]> javascriptGeneratedTestSet = Map.ofEntries(
@@ -145,9 +145,9 @@ public class RevocationListTest {
     @DisplayName("Successfuly decodes list generated by javascript version")
     void itDecodesListBuiltByJavascriptVersionOfTheLib() throws IOException {
         for (Map.Entry<String, int[]> entry : this.javascriptGeneratedTestSet.entrySet()) {
-            RevocationList list = RevocationList.decodeList(entry.getKey());
-            assertEquals(RevocationList.DEFAULT_LIST_BIT_SIZE, list.getSize());
-            validateRevocationListValues(list, entry.getValue());
+            StatusList list = StatusList.decodeList(entry.getKey());
+            assertEquals(StatusList.DEFAULT_LIST_BIT_SIZE, list.getSize());
+            validateStatusListValues(list, entry.getValue());
         }
     }
 
@@ -155,7 +155,7 @@ public class RevocationListTest {
      * Helper functions
      */
 
-    private void validateRevocationListValues(RevocationList list, int[] indicesSet) {
+    private void validateStatusListValues(StatusList list, int[] indicesSet) {
         for (int index = 0; index < list.getSize(); index++) {
             if (Arrays.binarySearch(indicesSet, index) > -1) {
                 assertTrue(list.isRevoked(index));

--- a/lib/src/test/java/demo/DemoTest.java
+++ b/lib/src/test/java/demo/DemoTest.java
@@ -55,12 +55,12 @@ public class DemoTest {
     void create() throws IOException, ReceiptStatusException, PrecheckStatusException, TimeoutException {
 
         var hfsVc = new HfsVcSl(client, VC_STATUS_LIST_OWNER_PRIVATE_KEY);
-        var VC_STATUS_LIST_FILE_ID = hfsVc.createRevocationListFile();
+        var VC_STATUS_LIST_FILE_ID = hfsVc.createStatusListFile();
 
         System.out.printf("VC_STATUS_LIST_FILE_ID: %s%n", VC_STATUS_LIST_FILE_ID.toString());
         System.out.printf("VC_STATUS_LIST_OWNER_PRIVATE_KEY: %s%n", VC_STATUS_LIST_OWNER_PRIVATE_KEY.toString());
 
-        System.out.println(hfsVc.loadRevocationList(VC_STATUS_LIST_FILE_ID).getBitset().toString());
+        System.out.println(hfsVc.loadStatusList(VC_STATUS_LIST_FILE_ID).getBitset().toString());
 
     }
 
@@ -71,7 +71,7 @@ public class DemoTest {
         var hfsVc = new HfsVcSl(client, VC_STATUS_LIST_OWNER_PRIVATE_KEY);
 
         var resolveStatus = hfsVc.resolveStatusByIndex(this.VC_STATUS_LIST_FILE_ID, 0);
-        var rl = hfsVc.loadRevocationList(this.VC_STATUS_LIST_FILE_ID);
+        var rl = hfsVc.loadStatusList(this.VC_STATUS_LIST_FILE_ID);
 
         System.out.println("==== status ====");
         System.out.println(resolveStatus);
@@ -91,7 +91,7 @@ public class DemoTest {
 
         System.out.printf("Revoked by index position %d%n", statusIndex);
 
-        System.out.printf("status list %s", hfsVc.loadRevocationList(VC_STATUS_LIST_FILE_ID).getBitset().toString());
+        System.out.printf("status list %s", hfsVc.loadStatusList(VC_STATUS_LIST_FILE_ID).getBitset().toString());
     }
 
     @Test
@@ -104,7 +104,7 @@ public class DemoTest {
 
         System.out.printf("Active by index position %d%n", statusIndex);
 
-        System.out.println(hfsVc.loadRevocationList(VC_STATUS_LIST_FILE_ID).getBitset().toString());
+        System.out.println(hfsVc.loadStatusList(VC_STATUS_LIST_FILE_ID).getBitset().toString());
 
     }
 
@@ -118,7 +118,7 @@ public class DemoTest {
 
         System.out.printf("Suspend by index position %d%n", statusIndex);
 
-        System.out.println(hfsVc.loadRevocationList(VC_STATUS_LIST_FILE_ID).getBitset().toString());
+        System.out.println(hfsVc.loadStatusList(VC_STATUS_LIST_FILE_ID).getBitset().toString());
 
     }
 
@@ -132,7 +132,7 @@ public class DemoTest {
 
         System.out.printf("Resume by index position %d%n", statusIndex);
 
-        System.out.println(hfsVc.loadRevocationList(VC_STATUS_LIST_FILE_ID).getBitset().toString());
+        System.out.println(hfsVc.loadStatusList(VC_STATUS_LIST_FILE_ID).getBitset().toString());
 
     }
 


### PR DESCRIPTION
Change 'revocation list' wording with 'status list' to keep it more consistent around the codebase.